### PR TITLE
Release version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 Changes to the project.
 
+## [1.0.0] - 2022-11-04
+
+**BREAKING CHANGE: All prometheus metrics and env variables has been renamed.**
+
+### Added
+- Prometheus metric names have `utxo_node` prefix instead of the old `bitcoin`
+- Env variables have `UTXO_NODE` prefix instead of the old `BITCOIN`
+- All prometheus metrics have label `blockchain` which can be set with `UTXO_NODE_BLOCKCHAIN_NAME` env variable.
+- Configuration has been extracted to separate file - `config.py`
+- Prometheus metrics have been extracted to separate file - `prometheus_metrics.py`
+
 ## [0.8.0] - 2022-11-02
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN pip install --no-cache-dir \
         riprova
 
 RUN mkdir -p /exporter
-ADD ./utxo_prometheus_exporter.py /exporter
+COPY . /exporter
 
 USER nobody
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ podTemplate(label: 'utxo-prometheus-exporter', containers: [
       container('docker') {
         def scmVars = checkout scm
         def PROJECT_NAME = "utxo-prometheus-exporter"
-        def VERSION = "0.8"
+        def VERSION = "1.0.0"
 
         sh "docker build -t santiment/${PROJECT_NAME}:latest -t santiment/${PROJECT_NAME}:${VERSION} ."
 

--- a/README.md
+++ b/README.md
@@ -15,25 +15,89 @@ The main script is a modified version of [`bitcoin-monitor.py`][source-gist], up
 [python-bitcoinlib]: https://github.com/petertodd/python-bitcoinlib
 [dashboard]: https://grafana.com/grafana/dashboards/11274
 
-# Run the container
-```
+## Usage
+
+### Run without docker
+
+1. You need to have python >= 3.8 and [pipenv]
+2. Install dependencies:
+
+    pipenv install
+
+3. Load the environment:
+
+    pipenv shell
+
+4. Run the script:
+
+    UTXO_NODE_RPC_HOST=bitcoin-node-address \
+    UTXO_NODE_RPC_USER=rpc-username \
+    UTXO_NODE_RPC_PASSWORD=rpc-password \
+    python3 utxo_prometheus_exporter.py
+
+[pipenv]: https://pipenv.pypa.io/en/latest/
+
+### Run with docker
+```sh
 docker run \
     --name=utxo-prometheus-exporter \
     -p 9332:9332 \
-    -e BITCOIN_RPC_HOST=bitcoin-node \
-    -e BITCOIN_RPC_USER=alice \
-    -e BITCOIN_RPC_PASSWORD=DONT_USE_THIS_YOU_WILL_GET_ROBBED_8ak1gI25KFTvjovL3gAM967mies3E= \
+    -e UTXO_NODE_BLOCKCHAIN_NAME=bitcoin
+    -e UTXO_NODE_RPC_HOST=bitcoin-node \
+    -e UTXO_NODE_RPC_USER=alice \
+    -e UTXO_NODE_RPC_PASSWORD=DONT_USE_THIS_YOU_WILL_GET_ROBBED_8ak1gI25KFTvjovL3gAM967mies3E= \
     santiment/utxo-prometheus-exporter:latest
 ```
 
+### Run in Kubernetes
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litecoin-prometheus-exporter
+  labels:
+    app: litecoin-prometheus-exporter
+spec:
+  selector:
+    matchLabels:
+      app: litecoin-prometheus-exporter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: litecoin-prometheus-exporter
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port:   '9335'
+    spec:
+      containers:
+        - name: litecoin-prometheus-exporter
+          image: santiment/utxo-prometheus-exporter:latest
+          imagePullPolicy: Always
+          env:
+            - name: UTXO_NODE_BLOCKCHAIN_NAME
+              value: litecoin
+            - name: UTXO_NODE_RPC_HOST
+              value: "litecoin-node.default"
+            - name: UTXO_NODE_RPC_PORT
+              value: "9332"
+            - name: UTXO_NODE_RPC_USER
+              value: "rpc-user"
+            - name: UTXO_NODE_RPC_PASSWORD
+              value: "rpc-password"
+            - name: REFRESH_SECONDS
+              value: "1"
+            - name: METRICS_PORT
+              value: "9335"
+```
+
 ## Basic Testing
-There's a [`docker-compose.yml`](docker-compose.yml) file in the repository that references a test bitcoin node. To
-test changes to the exporter in docker, run the following commands.
+There's a [`docker-compose.yml`](docker-compose.yml) file in the repository that references a test bitcoin node. To test changes to the exporter in docker, run the following commands.
 
 ```
 docker-compose down
-docker-compose build
-docker-compose up
+docker-compose up --build
 ```
 
 If you see a lot of `ConnectionRefusedError` errors, run `chmod og+r test-bitcoin.conf`.

--- a/config.py
+++ b/config.py
@@ -4,6 +4,8 @@ from distutils.util import strtobool
 # Set up logging to look similar to bitcoin logs (UTC).
 LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
 
+UTXO_NODE_BLOCKCHAIN_NAME = os.environ.get("UTXO_NODE_BLOCKCHAIN_NAME", "bitcoin")
+
 UTXO_NODE_RPC_SCHEME = os.environ.get("UTXO_NODE_RPC_SCHEME", "http")
 UTXO_NODE_RPC_HOST = os.environ.get("UTXO_NODE_RPC_HOST", "localhost")
 UTXO_NODE_RPC_PORT = os.environ.get("UTXO_NODE_RPC_PORT", "8332")

--- a/config.py
+++ b/config.py
@@ -1,0 +1,33 @@
+import os
+from distutils.util import strtobool
+
+# Set up logging to look similar to bitcoin logs (UTC).
+LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
+
+UTXO_NODE_RPC_SCHEME = os.environ.get("UTXO_NODE_RPC_SCHEME", "http")
+UTXO_NODE_RPC_HOST = os.environ.get("UTXO_NODE_RPC_HOST", "localhost")
+UTXO_NODE_RPC_PORT = os.environ.get("UTXO_NODE_RPC_PORT", "8332")
+UTXO_NODE_RPC_USER = os.environ.get("UTXO_NODE_RPC_USER")
+UTXO_NODE_RPC_PASSWORD = os.environ.get("UTXO_NODE_RPC_PASSWORD")
+UTXO_NODE_CONF_PATH = os.environ.get("UTXO_NODE_CONF_PATH")
+HASHPS_BLOCKS = [int(b) for b in os.environ.get("HASHPS_BLOCKS", "-1,1,120").split(",") if b != ""]
+SMART_FEES = [int(f) for f in os.environ.get("SMARTFEE_BLOCKS", "2,3,5,20").split(",") if f != ""]
+METRICS_ADDR = os.environ.get("METRICS_ADDR", "")  # empty = any address
+METRICS_PORT = int(os.environ.get("METRICS_PORT", "9332"))
+RETRIES = int(os.environ.get("RETRIES", 5))
+TIMEOUT = int(os.environ.get("TIMEOUT", 30))
+RATE_LIMIT_SECONDS = int(os.environ.get("RATE_LIMIT", 5))
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+
+FETCH_UPTIME = strtobool(os.environ.get("FETCH_UPTIME", 'True'))
+FETCH_MEMINFO = strtobool(os.environ.get("FETCH_MEMINFO", 'True'))
+FETCH_BLOCKCHAININFO = strtobool(os.environ.get("FETCH_BLOCKCHAININFO", 'True'))
+FETCH_NETWORKINFO = strtobool(os.environ.get("FETCH_NETWORKINFO", 'True'))
+FETCH_CHAINTIPS = strtobool(os.environ.get("FETCH_CHAINTIPS", 'True'))
+FETCH_MEMPOOLINFO = strtobool(os.environ.get("FETCH_MEMPOOLINFO", 'True'))
+FETCH_NETTOTALS = strtobool(os.environ.get("FETCH_NETTOTALS", 'True'))
+FETCH_RPCINFO = strtobool(os.environ.get("FETCH_RPCINFO", 'True'))
+FETCH_TXSTATS = strtobool(os.environ.get("FETCH_TXSTATS", 'True'))
+FETCH_BANNED = strtobool(os.environ.get("FETCH_BANNED", 'True'))
+FETCH_SMART_FEES = strtobool(os.environ.get("FETCH_SMART_FEES", 'True'))
+FETCH_HASHP_BLOCKS = strtobool(os.environ.get("FETCH_HASHP_BLOCKS", 'True'))

--- a/dashboard/bitcoin-grafana.json
+++ b/dashboard/bitcoin-grafana.json
@@ -1,34 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "6.4.1"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -38,23 +8,40 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
+  "id": 601,
+  "iteration": 1667565405711,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "Number of blocks created per day using different trailing rates.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -63,6 +50,7 @@
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 18,
       "legend": {
         "avg": false,
@@ -77,9 +65,10 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.3.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -89,33 +78,55 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "floor(sum(rate(bitcoin_blocks[3h])) * 3600 * 24)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "floor(sum(rate(utxo_node_blocks{blockchain=\"$blockchain\"}[3h])) * 3600 * 24)",
           "hide": false,
+          "interval": "",
           "legendFormat": "3h",
           "refId": "C"
         },
         {
-          "expr": "floor(sum(rate(bitcoin_blocks[6h])) * 3600 * 24)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "floor(sum(rate(utxo_node_blocks{blockchain=\"$blockchain\"}[6h])) * 3600 * 24)",
           "hide": false,
+          "interval": "",
           "legendFormat": "6h",
           "refId": "E"
         },
         {
-          "expr": "floor(sum(rate(bitcoin_blocks[12h])) * 3600 * 24)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "floor(sum(rate(utxo_node_blocks{blockchain=\"$blockchain\"}[12h])) * 3600 * 24)",
           "hide": false,
+          "interval": "",
           "legendFormat": "12h",
           "refId": "A"
         },
         {
-          "expr": "floor(sum(rate(bitcoin_blocks[7d])) * 3600 * 24)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "floor(sum(rate(utxo_node_blocks{blockchain=\"$blockchain\"}[7d])) * 3600 * 24)",
+          "interval": "",
           "legendFormat": "7d",
           "refId": "B"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Block Creation Rate",
       "tooltip": {
         "shared": true,
@@ -124,33 +135,26 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:86",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:87",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -158,8 +162,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "Difficulty value",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -168,6 +181,7 @@
         "x": 12,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 6,
       "legend": {
         "avg": false,
@@ -183,9 +197,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.3.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -195,17 +210,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(bitcoin_difficulty)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vwCxHkxnk"
+          },
+          "exemplar": true,
+          "expr": "avg(utxo_node_difficulty{blockchain=\"$blockchain\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "difficulty",
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Difficulty",
       "tooltip": {
         "shared": true,
@@ -214,34 +233,27 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:162",
           "decimals": 1,
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:163",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -249,8 +261,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "Estimated network hashes per second",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -259,6 +280,7 @@
         "x": 0,
         "y": 8
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "avg": false,
@@ -274,9 +296,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.3.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -286,24 +309,34 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(bitcoin_hashps)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "avg(utxo_node_hashps{blockchain=\"$blockchain\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "120-blocks",
           "refId": "B"
         },
         {
-          "expr": "avg(bitcoin_hashps_neg1)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "avg(utxo_node_hashps_neg1{blockchain=\"$blockchain\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "last-difficulty",
           "refId": "C"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Network Hash Rate",
       "tooltip": {
         "shared": true,
@@ -312,34 +345,27 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:238",
           "decimals": 0,
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:239",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -347,8 +373,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "Value of the block transactions in BTC.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -357,6 +392,7 @@
         "x": 12,
         "y": 8
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "avg": false,
@@ -372,9 +408,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.3.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -384,17 +421,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(bitcoin_latest_block_value)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vwCxHkxnk"
+          },
+          "exemplar": true,
+          "expr": "sum(utxo_node_latest_block_value{blockchain=\"$blockchain\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "BTC",
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Block value",
       "tooltip": {
         "shared": true,
@@ -403,33 +444,26 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:388",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:389",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -437,8 +471,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "Number of tips seen in the chain.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -447,6 +490,7 @@
         "x": 0,
         "y": 16
       },
+      "hiddenSeries": false,
       "id": 12,
       "legend": {
         "avg": false,
@@ -462,9 +506,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.3.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -474,17 +519,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(bitcoin_num_chaintips)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "avg(utxo_node_num_chaintips{blockchain=\"$blockchain\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "tips",
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Chain Branches",
       "tooltip": {
         "shared": true,
@@ -493,35 +542,28 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:464",
           "decimals": 0,
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:465",
           "decimals": 0,
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -529,8 +571,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "Sent and received traffic rates",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -539,6 +590,7 @@
         "x": 12,
         "y": 16
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "avg": false,
@@ -554,9 +606,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.3.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -566,24 +619,34 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(bitcoin_total_bytes_sent[5m]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(irate(utxo_node_total_bytes_sent{blockchain=\"$blockchain\"}[5m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "sent",
           "refId": "A"
         },
         {
-          "expr": "-sum(irate(bitcoin_total_bytes_recv[10m]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "-sum(irate(utxo_node_total_bytes_recv{blockchain=\"$blockchain\"}[10m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "received",
           "refId": "B"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Network traffic",
       "tooltip": {
         "shared": true,
@@ -592,34 +655,27 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:540",
           "decimals": 0,
           "format": "Bps",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:541",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -627,8 +683,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "The estimated smart fee for confirmation of transactions in a given number of blocks.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -637,6 +702,7 @@
         "x": 0,
         "y": 24
       },
+      "hiddenSeries": false,
       "id": 4,
       "legend": {
         "avg": false,
@@ -652,9 +718,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.3.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -664,7 +731,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(bitcoin_est_smart_fee_2)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "avg(utxo_node_est_smart_fee_2{blockchain=\"$blockchain\"})",
           "format": "time_series",
           "interval": "2m",
           "intervalFactor": 1,
@@ -672,31 +744,47 @@
           "refId": "A"
         },
         {
-          "expr": "avg(bitcoin_est_smart_fee_20)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "avg(utxo_node_est_smart_fee_20{blockchain=\"$blockchain\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "20-blocks",
           "refId": "B"
         },
         {
-          "expr": "avg(bitcoin_est_smart_fee_3)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "avg(utxo_node_est_smart_fee_3{blockchain=\"$blockchain\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "3-blocks",
           "refId": "C"
         },
         {
-          "expr": "avg(bitcoin_est_smart_fee_5)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "avg(utxo_node_est_smart_fee_5{blockchain=\"$blockchain\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "5-blocks",
           "refId": "D"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Estimated Fee",
       "tooltip": {
         "shared": true,
@@ -705,33 +793,26 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:616",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:617",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -739,8 +820,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "The Bitcoin protocol and server versions.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -749,6 +839,7 @@
         "x": 12,
         "y": 24
       },
+      "hiddenSeries": false,
       "id": 14,
       "legend": {
         "avg": false,
@@ -764,9 +855,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.3.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -785,24 +877,34 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(bitcoin_protocol_version)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "avg(utxo_node_protocol_version{blockchain=\"$blockchain\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "protocol",
           "refId": "A"
         },
         {
-          "expr": "avg(bitcoin_server_version)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "avg(utxo_node_server_version{blockchain=\"$blockchain\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "server",
           "refId": "B"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Versions",
       "tooltip": {
         "shared": true,
@@ -811,34 +913,28 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
+          "$$hashKey": "object:692",
           "format": "none",
           "label": "protocol version",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:693",
           "format": "none",
           "label": "server version",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -846,8 +942,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "Number of peers that have been banned and the reason for the ban.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -856,6 +961,7 @@
         "x": 0,
         "y": 32
       },
+      "hiddenSeries": false,
       "id": 16,
       "legend": {
         "avg": false,
@@ -871,9 +977,10 @@
       "links": [],
       "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "8.3.6",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -883,24 +990,34 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(bitcoin_banned_until) by (reason)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "count(utxo_node_banned_until{blockchain=\"$blockchain\"}) by (reason)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "ban - {{ reason }}",
           "refId": "B"
         },
         {
-          "expr": "sum(bitcoin_peers)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(utxo_node_peers{blockchain=\"$blockchain\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "peers",
           "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Peers",
       "tooltip": {
         "shared": true,
@@ -909,49 +1026,85 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:842",
           "decimals": 0,
           "format": "none",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:843",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
-  "refresh": "5m",
-  "schemaVersion": 20,
+  "refresh": false,
+  "schemaVersion": 34,
   "style": "dark",
-  "tags": [
-    "bitcoin"
-  ],
+  "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "litecoin",
+          "value": "litecoin"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(utxo_node_blocks, blockchain)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "blockchain",
+        "options": [],
+        "query": {
+          "query": "label_values(utxo_node_blocks, blockchain)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus-aws-stage",
+          "value": "Prometheus-aws-stage"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
-    "from": "now-1w",
-    "to": "now"
+    "from": "2022-11-04T09:32:47.488Z",
+    "to": "2022-11-04T09:35:17.358Z"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -979,7 +1132,8 @@
     ]
   },
   "timezone": "",
-  "title": "Bitcoin",
-  "uid": "OTLC2jHWz",
-  "version": 1
+  "title": "utxo-node-prometheus-exporter Copy",
+  "uid": "eya1_Wv4z",
+  "version": 5,
+  "weekStart": ""
 }

--- a/prometheus_metrics.py
+++ b/prometheus_metrics.py
@@ -3,94 +3,97 @@ from prometheus_client import Gauge, Counter
 
 METRIC_PREFIX = "utxo_node"
 
-UTXO_NODE_BLOCKS = Gauge(f"{METRIC_PREFIX}_blocks", "Block height")
-UTXO_NODE_DIFFICULTY = Gauge(f"{METRIC_PREFIX}_difficulty", "Difficulty")
-UTXO_NODE_PEERS = Gauge(f"{METRIC_PREFIX}_peers", "Number of peers")
-UTXO_NODE_CONN_IN = Gauge(f"{METRIC_PREFIX}_conn_in", "Number of connections in")
-UTXO_NODE_CONN_OUT = Gauge(f"{METRIC_PREFIX}_conn_out", "Number of connections out")
+UTXO_NODE_BLOCKS = Gauge(f"{METRIC_PREFIX}_blocks", "Block height", labelnames=["blockchain"])
+UTXO_NODE_DIFFICULTY = Gauge(f"{METRIC_PREFIX}_difficulty", "Difficulty", labelnames=["blockchain"])
+UTXO_NODE_PEERS = Gauge(f"{METRIC_PREFIX}_peers", "Number of peers", labelnames=["blockchain"])
+UTXO_NODE_CONN_IN = Gauge(f"{METRIC_PREFIX}_conn_in", "Number of connections in", labelnames=["blockchain"])
+UTXO_NODE_CONN_OUT = Gauge(f"{METRIC_PREFIX}_conn_out", "Number of connections out", labelnames=["blockchain"])
 
 UTXO_NODE_HASHPS_GAUGES = {}  # type: Dict[int, Gauge]
 UTXO_NODE_ESTIMATED_SMART_FEE_GAUGES = {}  # type: Dict[int, Gauge]
 
 UTXO_NODE_WARNINGS = Counter(
     f"{METRIC_PREFIX}_warnings",
-    "Number of network or blockchain warnings detected"
+    "Number of network or blockchain warnings detected",
+    labelnames=["blockchain"]
 )
 UTXO_NODE_UPTIME = Gauge(
     f"{METRIC_PREFIX}_uptime",
-    "Number of seconds the node has been running"
+    "Number of seconds the node has been running",
+    labelnames=["blockchain"]
 )
 
-UTXO_NODE_MEMINFO_USED = Gauge(f"{METRIC_PREFIX}_meminfo_used", "Number of bytes used")
-UTXO_NODE_MEMINFO_FREE = Gauge(f"{METRIC_PREFIX}_meminfo_free", "Number of bytes available")
-UTXO_NODE_MEMINFO_TOTAL = Gauge(f"{METRIC_PREFIX}_meminfo_total", "Number of bytes managed")
-UTXO_NODE_MEMINFO_LOCKED = Gauge(f"{METRIC_PREFIX}_meminfo_locked", "Number of bytes locked")
-UTXO_NODE_MEMINFO_CHUNKS_USED = Gauge(f"{METRIC_PREFIX}_meminfo_chunks_used", "Number of allocated chunks")
-UTXO_NODE_MEMINFO_CHUNKS_FREE = Gauge(f"{METRIC_PREFIX}_meminfo_chunks_free", "Number of unused chunks")
+UTXO_NODE_MEMINFO_USED = Gauge(f"{METRIC_PREFIX}_meminfo_used", "Number of bytes used", labelnames=["blockchain"])
+UTXO_NODE_MEMINFO_FREE = Gauge(f"{METRIC_PREFIX}_meminfo_free", "Number of bytes available", labelnames=["blockchain"])
+UTXO_NODE_MEMINFO_TOTAL = Gauge(f"{METRIC_PREFIX}_meminfo_total", "Number of bytes managed", labelnames=["blockchain"])
+UTXO_NODE_MEMINFO_LOCKED = Gauge(f"{METRIC_PREFIX}_meminfo_locked", "Number of bytes locked", labelnames=["blockchain"])
+UTXO_NODE_MEMINFO_CHUNKS_USED = Gauge(f"{METRIC_PREFIX}_meminfo_chunks_used", "Number of allocated chunks", labelnames=["blockchain"])
+UTXO_NODE_MEMINFO_CHUNKS_FREE = Gauge(f"{METRIC_PREFIX}_meminfo_chunks_free", "Number of unused chunks", labelnames=["blockchain"])
 
-UTXO_NODE_MEMPOOL_BYTES = Gauge(f"{METRIC_PREFIX}_mempool_bytes", "Size of mempool in bytes")
+UTXO_NODE_MEMPOOL_BYTES = Gauge(f"{METRIC_PREFIX}_mempool_bytes", "Size of mempool in bytes", labelnames=["blockchain"])
 UTXO_NODE_MEMPOOL_SIZE = Gauge(
-    f"{METRIC_PREFIX}_mempool_size", "Number of unconfirmed transactions in mempool"
+    f"{METRIC_PREFIX}_mempool_size", "Number of unconfirmed transactions in mempool",
+    labelnames=["blockchain"]
 )
-UTXO_NODE_MEMPOOL_USAGE = Gauge(f"{METRIC_PREFIX}_mempool_usage", "Total memory usage for the mempool")
+UTXO_NODE_MEMPOOL_USAGE = Gauge(f"{METRIC_PREFIX}_mempool_usage", "Total memory usage for the mempool", labelnames=["blockchain"])
 UTXO_NODE_MEMPOOL_UNBROADCAST = Gauge(
-    f"{METRIC_PREFIX}_mempool_unbroadcast", "Number of transactions waiting for acknowledgment"
+    f"{METRIC_PREFIX}_mempool_unbroadcast", "Number of transactions waiting for acknowledgment", labelnames=["blockchain"]
 )
 
 UTXO_NODE_LATEST_BLOCK_HEIGHT = Gauge(
-    f"{METRIC_PREFIX}_latest_block_height", "Height or index of latest block"
+    f"{METRIC_PREFIX}_latest_block_height", "Height or index of latest block", labelnames=["blockchain"]
 )
 UTXO_NODE_LATEST_BLOCK_WEIGHT = Gauge(
-    f"{METRIC_PREFIX}_latest_block_weight", "Weight of latest block according to BIP 141"
+    f"{METRIC_PREFIX}_latest_block_weight", "Weight of latest block according to BIP 141", labelnames=["blockchain"]
 )
-UTXO_NODE_LATEST_BLOCK_SIZE = Gauge(f"{METRIC_PREFIX}_latest_block_size", "Size of latest block in bytes")
+UTXO_NODE_LATEST_BLOCK_SIZE = Gauge(f"{METRIC_PREFIX}_latest_block_size", "Size of latest block in bytes", labelnames=["blockchain"])
 UTXO_NODE_LATEST_BLOCK_TXS = Gauge(
-    f"{METRIC_PREFIX}_latest_block_txs", "Number of transactions in latest block"
+    f"{METRIC_PREFIX}_latest_block_txs", "Number of transactions in latest block", labelnames=["blockchain"]
 )
 
-UTXO_NODE_TXCOUNT = Gauge(f"{METRIC_PREFIX}_txcount", "Number of TX since the genesis block")
+UTXO_NODE_TXCOUNT = Gauge(f"{METRIC_PREFIX}_txcount", "Number of TX since the genesis block", labelnames=["blockchain"])
 
-UTXO_NODE_NUM_CHAINTIPS = Gauge(f"{METRIC_PREFIX}_num_chaintips", "Number of known blockchain branches")
+UTXO_NODE_NUM_CHAINTIPS = Gauge(f"{METRIC_PREFIX}_num_chaintips", "Number of known blockchain branches", labelnames=["blockchain"])
 
-UTXO_NODE_TOTAL_BYTES_RECV = Gauge(f"{METRIC_PREFIX}_total_bytes_recv", "Total bytes received")
-UTXO_NODE_TOTAL_BYTES_SENT = Gauge(f"{METRIC_PREFIX}_total_bytes_sent", "Total bytes sent")
+UTXO_NODE_TOTAL_BYTES_RECV = Gauge(f"{METRIC_PREFIX}_total_bytes_recv", "Total bytes received", labelnames=["blockchain"])
+UTXO_NODE_TOTAL_BYTES_SENT = Gauge(f"{METRIC_PREFIX}_total_bytes_sent", "Total bytes sent", labelnames=["blockchain"])
 
 UTXO_NODE_LATEST_BLOCK_INPUTS = Gauge(
-    f"{METRIC_PREFIX}_latest_block_inputs", "Number of inputs in transactions of latest block"
+    f"{METRIC_PREFIX}_latest_block_inputs", "Number of inputs in transactions of latest block", labelnames=["blockchain"]
 )
 UTXO_NODE_LATEST_BLOCK_OUTPUTS = Gauge(
-    f"{METRIC_PREFIX}_latest_block_outputs", "Number of outputs in transactions of latest block"
+    f"{METRIC_PREFIX}_latest_block_outputs", "Number of outputs in transactions of latest block", labelnames=["blockchain"]
 )
 UTXO_NODE_LATEST_BLOCK_VALUE = Gauge(
-    f"{METRIC_PREFIX}_latest_block_value", "Bitcoin value of all transactions in the latest block"
+    f"{METRIC_PREFIX}_latest_block_value", "Bitcoin value of all transactions in the latest block", labelnames=["blockchain"]
 )
 UTXO_NODE_LATEST_BLOCK_FEE = Gauge(
-    f"{METRIC_PREFIX}_latest_block_fee", "Total fee to process the latest block"
+    f"{METRIC_PREFIX}_latest_block_fee", "Total fee to process the latest block", labelnames=["blockchain"]
 )
 
 UTXO_NODE_BAN_CREATED = Gauge(
-    f"{METRIC_PREFIX}_ban_created", "Time the ban was created", labelnames=["address", "reason"]
+    f"{METRIC_PREFIX}_ban_created", "Time the ban was created", labelnames=["address", "reason", "blockchain"]
 )
 UTXO_NODE_BANNED_UNTIL = Gauge(
-    f"{METRIC_PREFIX}_banned_until", "Time the ban expires", labelnames=["address", "reason"]
+    f"{METRIC_PREFIX}_banned_until", "Time the ban expires", labelnames=["address", "reason", "blockchain"]
 )
 
-UTXO_NODE_SERVER_VERSION = Gauge(f"{METRIC_PREFIX}_server_version", "The server version")
-UTXO_NODE_PROTOCOL_VERSION = Gauge(f"{METRIC_PREFIX}_protocol_version", "The protocol version of the server")
+UTXO_NODE_SERVER_VERSION = Gauge(f"{METRIC_PREFIX}_server_version", "The server version", labelnames=["blockchain"])
+UTXO_NODE_PROTOCOL_VERSION = Gauge(f"{METRIC_PREFIX}_protocol_version", "The protocol version of the server", labelnames=["blockchain"])
 
-UTXO_NODE_SIZE_ON_DISK = Gauge(f"{METRIC_PREFIX}_size_on_disk", "Estimated size of the block and undo files")
+UTXO_NODE_SIZE_ON_DISK = Gauge(f"{METRIC_PREFIX}_size_on_disk", "Estimated size of the block and undo files", labelnames=["blockchain"])
 
 UTXO_NODE_VERIFICATION_PROGRESS = Gauge(
-    f"{METRIC_PREFIX}_verification_progress", "Estimate of verification progress [0..1]"
+    f"{METRIC_PREFIX}_verification_progress", "Estimate of verification progress [0..1]", labelnames=["blockchain"]
 )
 
-UTXO_NODE_RPC_ACTIVE = Gauge(f"{METRIC_PREFIX}_rpc_active", "Number of RPC calls being processed")
+UTXO_NODE_RPC_ACTIVE = Gauge(f"{METRIC_PREFIX}_rpc_active", "Number of RPC calls being processed", labelnames=["blockchain"])
 
 EXPORTER_ERRORS = Counter(
-    f"{METRIC_PREFIX}_exporter_errors", "Number of errors encountered by the exporter", labelnames=["type"]
+    f"{METRIC_PREFIX}_exporter_errors", "Number of errors encountered by the exporter", labelnames=["type", "blockchain"]
 )
 PROCESS_TIME = Counter(
-    f"{METRIC_PREFIX}_exporter_process_time", "Time spent processing metrics from node"
+    f"{METRIC_PREFIX}_exporter_process_time", "Time spent processing metrics from node", labelnames=["blockchain"]
 )
 
 SATS_PER_COIN = Decimal(1e8)
@@ -112,6 +115,7 @@ def hashps_gauge(num_blocks: int) -> Gauge:
         gauge = Gauge(
             f"{METRIC_PREFIX}_hashps%s" % hashps_gauge_suffix(num_blocks),
             "Estimated network hash rate per second %s" % desc_end,
+            labelnames=["blockchain"]
         )
         UTXO_NODE_HASHPS_GAUGES[num_blocks] = gauge
     return gauge
@@ -122,6 +126,7 @@ def smartfee_gauge(num_blocks: int) -> Gauge:
         gauge = Gauge(
             f"{METRIC_PREFIX}_est_smart_fee_%d" % num_blocks,
             "Estimated smart fee per kilobyte for confirmation in %d blocks" % num_blocks,
+            labelnames=["blockchain"]
         )
         UTXO_NODE_ESTIMATED_SMART_FEE_GAUGES[num_blocks] = gauge
     return gauge

--- a/prometheus_metrics.py
+++ b/prometheus_metrics.py
@@ -1,0 +1,127 @@
+from decimal import Decimal
+from prometheus_client import Gauge, Counter
+
+METRIC_PREFIX = "utxo_node"
+
+UTXO_NODE_BLOCKS = Gauge(f"{METRIC_PREFIX}_blocks", "Block height")
+UTXO_NODE_DIFFICULTY = Gauge(f"{METRIC_PREFIX}_difficulty", "Difficulty")
+UTXO_NODE_PEERS = Gauge(f"{METRIC_PREFIX}_peers", "Number of peers")
+UTXO_NODE_CONN_IN = Gauge(f"{METRIC_PREFIX}_conn_in", "Number of connections in")
+UTXO_NODE_CONN_OUT = Gauge(f"{METRIC_PREFIX}_conn_out", "Number of connections out")
+
+UTXO_NODE_HASHPS_GAUGES = {}  # type: Dict[int, Gauge]
+UTXO_NODE_ESTIMATED_SMART_FEE_GAUGES = {}  # type: Dict[int, Gauge]
+
+UTXO_NODE_WARNINGS = Counter(
+    f"{METRIC_PREFIX}_warnings",
+    "Number of network or blockchain warnings detected"
+)
+UTXO_NODE_UPTIME = Gauge(
+    f"{METRIC_PREFIX}_uptime",
+    "Number of seconds the node has been running"
+)
+
+UTXO_NODE_MEMINFO_USED = Gauge(f"{METRIC_PREFIX}_meminfo_used", "Number of bytes used")
+UTXO_NODE_MEMINFO_FREE = Gauge(f"{METRIC_PREFIX}_meminfo_free", "Number of bytes available")
+UTXO_NODE_MEMINFO_TOTAL = Gauge(f"{METRIC_PREFIX}_meminfo_total", "Number of bytes managed")
+UTXO_NODE_MEMINFO_LOCKED = Gauge(f"{METRIC_PREFIX}_meminfo_locked", "Number of bytes locked")
+UTXO_NODE_MEMINFO_CHUNKS_USED = Gauge(f"{METRIC_PREFIX}_meminfo_chunks_used", "Number of allocated chunks")
+UTXO_NODE_MEMINFO_CHUNKS_FREE = Gauge(f"{METRIC_PREFIX}_meminfo_chunks_free", "Number of unused chunks")
+
+UTXO_NODE_MEMPOOL_BYTES = Gauge(f"{METRIC_PREFIX}_mempool_bytes", "Size of mempool in bytes")
+UTXO_NODE_MEMPOOL_SIZE = Gauge(
+    f"{METRIC_PREFIX}_mempool_size", "Number of unconfirmed transactions in mempool"
+)
+UTXO_NODE_MEMPOOL_USAGE = Gauge(f"{METRIC_PREFIX}_mempool_usage", "Total memory usage for the mempool")
+UTXO_NODE_MEMPOOL_UNBROADCAST = Gauge(
+    f"{METRIC_PREFIX}_mempool_unbroadcast", "Number of transactions waiting for acknowledgment"
+)
+
+UTXO_NODE_LATEST_BLOCK_HEIGHT = Gauge(
+    f"{METRIC_PREFIX}_latest_block_height", "Height or index of latest block"
+)
+UTXO_NODE_LATEST_BLOCK_WEIGHT = Gauge(
+    f"{METRIC_PREFIX}_latest_block_weight", "Weight of latest block according to BIP 141"
+)
+UTXO_NODE_LATEST_BLOCK_SIZE = Gauge(f"{METRIC_PREFIX}_latest_block_size", "Size of latest block in bytes")
+UTXO_NODE_LATEST_BLOCK_TXS = Gauge(
+    f"{METRIC_PREFIX}_latest_block_txs", "Number of transactions in latest block"
+)
+
+UTXO_NODE_TXCOUNT = Gauge(f"{METRIC_PREFIX}_txcount", "Number of TX since the genesis block")
+
+UTXO_NODE_NUM_CHAINTIPS = Gauge(f"{METRIC_PREFIX}_num_chaintips", "Number of known blockchain branches")
+
+UTXO_NODE_TOTAL_BYTES_RECV = Gauge(f"{METRIC_PREFIX}_total_bytes_recv", "Total bytes received")
+UTXO_NODE_TOTAL_BYTES_SENT = Gauge(f"{METRIC_PREFIX}_total_bytes_sent", "Total bytes sent")
+
+UTXO_NODE_LATEST_BLOCK_INPUTS = Gauge(
+    f"{METRIC_PREFIX}_latest_block_inputs", "Number of inputs in transactions of latest block"
+)
+UTXO_NODE_LATEST_BLOCK_OUTPUTS = Gauge(
+    f"{METRIC_PREFIX}_latest_block_outputs", "Number of outputs in transactions of latest block"
+)
+UTXO_NODE_LATEST_BLOCK_VALUE = Gauge(
+    f"{METRIC_PREFIX}_latest_block_value", "Bitcoin value of all transactions in the latest block"
+)
+UTXO_NODE_LATEST_BLOCK_FEE = Gauge(
+    f"{METRIC_PREFIX}_latest_block_fee", "Total fee to process the latest block"
+)
+
+UTXO_NODE_BAN_CREATED = Gauge(
+    f"{METRIC_PREFIX}_ban_created", "Time the ban was created", labelnames=["address", "reason"]
+)
+UTXO_NODE_BANNED_UNTIL = Gauge(
+    f"{METRIC_PREFIX}_banned_until", "Time the ban expires", labelnames=["address", "reason"]
+)
+
+UTXO_NODE_SERVER_VERSION = Gauge(f"{METRIC_PREFIX}_server_version", "The server version")
+UTXO_NODE_PROTOCOL_VERSION = Gauge(f"{METRIC_PREFIX}_protocol_version", "The protocol version of the server")
+
+UTXO_NODE_SIZE_ON_DISK = Gauge(f"{METRIC_PREFIX}_size_on_disk", "Estimated size of the block and undo files")
+
+UTXO_NODE_VERIFICATION_PROGRESS = Gauge(
+    f"{METRIC_PREFIX}_verification_progress", "Estimate of verification progress [0..1]"
+)
+
+UTXO_NODE_RPC_ACTIVE = Gauge(f"{METRIC_PREFIX}_rpc_active", "Number of RPC calls being processed")
+
+EXPORTER_ERRORS = Counter(
+    f"{METRIC_PREFIX}_exporter_errors", "Number of errors encountered by the exporter", labelnames=["type"]
+)
+PROCESS_TIME = Counter(
+    f"{METRIC_PREFIX}_exporter_process_time", "Time spent processing metrics from node"
+)
+
+SATS_PER_COIN = Decimal(1e8)
+
+def hashps_gauge_suffix(nblocks):
+    if nblocks < 0:
+        return "_neg%d" % -nblocks
+    if nblocks == 120:
+        return ""
+    return "_%d" % nblocks
+
+
+def hashps_gauge(num_blocks: int) -> Gauge:
+    gauge = UTXO_NODE_HASHPS_GAUGES.get(num_blocks)
+    if gauge is None:
+        desc_end = "for the last %d blocks" % num_blocks
+        if num_blocks == -1:
+            desc_end = "since the last difficulty change"
+        gauge = Gauge(
+            f"{METRIC_PREFIX}_hashps%s" % hashps_gauge_suffix(num_blocks),
+            "Estimated network hash rate per second %s" % desc_end,
+        )
+        UTXO_NODE_HASHPS_GAUGES[num_blocks] = gauge
+    return gauge
+
+def smartfee_gauge(num_blocks: int) -> Gauge:
+    gauge = UTXO_NODE_ESTIMATED_SMART_FEE_GAUGES.get(num_blocks)
+    if gauge is None:
+        gauge = Gauge(
+            f"{METRIC_PREFIX}_est_smart_fee_%d" % num_blocks,
+            "Estimated smart fee per kilobyte for confirmation in %d blocks" % num_blocks,
+        )
+        UTXO_NODE_ESTIMATED_SMART_FEE_GAUGES[num_blocks] = gauge
+    return gauge

--- a/utxo_prometheus_exporter.py
+++ b/utxo_prometheus_exporter.py
@@ -23,7 +23,6 @@ import os
 import signal
 import sys
 import socket
-from decimal import Decimal
 from datetime import datetime
 from functools import lru_cache
 from typing import Any
@@ -37,107 +36,14 @@ from wsgiref.simple_server import make_server
 import riprova
 
 from bitcoin.rpc import JSONRPCError, InWarmupError, Proxy
-from prometheus_client import make_wsgi_app, Gauge, Counter
+from prometheus_client import make_wsgi_app
 
+from prometheus_metrics import *
 
 logger = logging.getLogger("utxo-prometheus-exporter")
 
 # Set up logging to look similar to bitcoin logs (UTC).
 LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
-
-METRIC_PREFIX = "utxo_node"
-
-UTXO_NODE_BLOCKS = Gauge(f"{METRIC_PREFIX}_blocks", "Block height")
-UTXO_NODE_DIFFICULTY = Gauge(f"{METRIC_PREFIX}_difficulty", "Difficulty")
-UTXO_NODE_PEERS = Gauge(f"{METRIC_PREFIX}_peers", "Number of peers")
-UTXO_NODE_CONN_IN = Gauge(f"{METRIC_PREFIX}_conn_in", "Number of connections in")
-UTXO_NODE_CONN_OUT = Gauge(f"{METRIC_PREFIX}_conn_out", "Number of connections out")
-
-UTXO_NODE_HASHPS_GAUGES = {}  # type: Dict[int, Gauge]
-UTXO_NODE_ESTIMATED_SMART_FEE_GAUGES = {}  # type: Dict[int, Gauge]
-
-UTXO_NODE_WARNINGS = Counter(
-    f"{METRIC_PREFIX}_warnings",
-    "Number of network or blockchain warnings detected"
-)
-UTXO_NODE_UPTIME = Gauge(
-    f"{METRIC_PREFIX}_uptime",
-    "Number of seconds the node has been running"
-)
-
-UTXO_NODE_MEMINFO_USED = Gauge(f"{METRIC_PREFIX}_meminfo_used", "Number of bytes used")
-UTXO_NODE_MEMINFO_FREE = Gauge(f"{METRIC_PREFIX}_meminfo_free", "Number of bytes available")
-UTXO_NODE_MEMINFO_TOTAL = Gauge(f"{METRIC_PREFIX}_meminfo_total", "Number of bytes managed")
-UTXO_NODE_MEMINFO_LOCKED = Gauge(f"{METRIC_PREFIX}_meminfo_locked", "Number of bytes locked")
-UTXO_NODE_MEMINFO_CHUNKS_USED = Gauge(f"{METRIC_PREFIX}_meminfo_chunks_used", "Number of allocated chunks")
-UTXO_NODE_MEMINFO_CHUNKS_FREE = Gauge(f"{METRIC_PREFIX}_meminfo_chunks_free", "Number of unused chunks")
-
-UTXO_NODE_MEMPOOL_BYTES = Gauge(f"{METRIC_PREFIX}_mempool_bytes", "Size of mempool in bytes")
-UTXO_NODE_MEMPOOL_SIZE = Gauge(
-    f"{METRIC_PREFIX}_mempool_size", "Number of unconfirmed transactions in mempool"
-)
-UTXO_NODE_MEMPOOL_USAGE = Gauge(f"{METRIC_PREFIX}_mempool_usage", "Total memory usage for the mempool")
-UTXO_NODE_MEMPOOL_UNBROADCAST = Gauge(
-    f"{METRIC_PREFIX}_mempool_unbroadcast", "Number of transactions waiting for acknowledgment"
-)
-
-UTXO_NODE_LATEST_BLOCK_HEIGHT = Gauge(
-    f"{METRIC_PREFIX}_latest_block_height", "Height or index of latest block"
-)
-UTXO_NODE_LATEST_BLOCK_WEIGHT = Gauge(
-    f"{METRIC_PREFIX}_latest_block_weight", "Weight of latest block according to BIP 141"
-)
-UTXO_NODE_LATEST_BLOCK_SIZE = Gauge(f"{METRIC_PREFIX}_latest_block_size", "Size of latest block in bytes")
-UTXO_NODE_LATEST_BLOCK_TXS = Gauge(
-    f"{METRIC_PREFIX}_latest_block_txs", "Number of transactions in latest block"
-)
-
-UTXO_NODE_TXCOUNT = Gauge(f"{METRIC_PREFIX}_txcount", "Number of TX since the genesis block")
-
-UTXO_NODE_NUM_CHAINTIPS = Gauge(f"{METRIC_PREFIX}_num_chaintips", "Number of known blockchain branches")
-
-UTXO_NODE_TOTAL_BYTES_RECV = Gauge(f"{METRIC_PREFIX}_total_bytes_recv", "Total bytes received")
-UTXO_NODE_TOTAL_BYTES_SENT = Gauge(f"{METRIC_PREFIX}_total_bytes_sent", "Total bytes sent")
-
-UTXO_NODE_LATEST_BLOCK_INPUTS = Gauge(
-    f"{METRIC_PREFIX}_latest_block_inputs", "Number of inputs in transactions of latest block"
-)
-UTXO_NODE_LATEST_BLOCK_OUTPUTS = Gauge(
-    f"{METRIC_PREFIX}_latest_block_outputs", "Number of outputs in transactions of latest block"
-)
-UTXO_NODE_LATEST_BLOCK_VALUE = Gauge(
-    f"{METRIC_PREFIX}_latest_block_value", "Bitcoin value of all transactions in the latest block"
-)
-UTXO_NODE_LATEST_BLOCK_FEE = Gauge(
-    f"{METRIC_PREFIX}_latest_block_fee", "Total fee to process the latest block"
-)
-
-UTXO_NODE_BAN_CREATED = Gauge(
-    f"{METRIC_PREFIX}_ban_created", "Time the ban was created", labelnames=["address", "reason"]
-)
-UTXO_NODE_BANNED_UNTIL = Gauge(
-    f"{METRIC_PREFIX}_banned_until", "Time the ban expires", labelnames=["address", "reason"]
-)
-
-UTXO_NODE_SERVER_VERSION = Gauge(f"{METRIC_PREFIX}_server_version", "The server version")
-UTXO_NODE_PROTOCOL_VERSION = Gauge(f"{METRIC_PREFIX}_protocol_version", "The protocol version of the server")
-
-UTXO_NODE_SIZE_ON_DISK = Gauge(f"{METRIC_PREFIX}_size_on_disk", "Estimated size of the block and undo files")
-
-UTXO_NODE_VERIFICATION_PROGRESS = Gauge(
-    f"{METRIC_PREFIX}_verification_progress", "Estimate of verification progress [0..1]"
-)
-
-UTXO_NODE_RPC_ACTIVE = Gauge(f"{METRIC_PREFIX}_rpc_active", "Number of RPC calls being processed")
-
-EXPORTER_ERRORS = Counter(
-    f"{METRIC_PREFIX}_exporter_errors", "Number of errors encountered by the exporter", labelnames=["type"]
-)
-PROCESS_TIME = Counter(
-    f"{METRIC_PREFIX}_exporter_process_time", "Time spent processing metrics from node"
-)
-
-SATS_PER_COIN = Decimal(1e8)
 
 UTXO_NODE_RPC_SCHEME = os.environ.get("UTXO_NODE_RPC_SCHEME", "http")
 UTXO_NODE_RPC_HOST = os.environ.get("UTXO_NODE_RPC_HOST", "localhost")
@@ -241,45 +147,11 @@ def getblockstats(block_hash: str):
         return None
     return block
 
-
-def smartfee_gauge(num_blocks: int) -> Gauge:
-    gauge = UTXO_NODE_ESTIMATED_SMART_FEE_GAUGES.get(num_blocks)
-    if gauge is None:
-        gauge = Gauge(
-            f"{METRIC_PREFIX}_est_smart_fee_%d" % num_blocks,
-            "Estimated smart fee per kilobyte for confirmation in %d blocks" % num_blocks,
-        )
-        UTXO_NODE_ESTIMATED_SMART_FEE_GAUGES[num_blocks] = gauge
-    return gauge
-
-
 def do_smartfee(num_blocks: int) -> None:
     smartfee = exec_rpc_call("estimatesmartfee", num_blocks).get("feerate")
     if smartfee is not None:
         gauge = smartfee_gauge(num_blocks)
         gauge.set(smartfee)
-
-
-def hashps_gauge_suffix(nblocks):
-    if nblocks < 0:
-        return "_neg%d" % -nblocks
-    if nblocks == 120:
-        return ""
-    return "_%d" % nblocks
-
-
-def hashps_gauge(num_blocks: int) -> Gauge:
-    gauge = UTXO_NODE_HASHPS_GAUGES.get(num_blocks)
-    if gauge is None:
-        desc_end = "for the last %d blocks" % num_blocks
-        if num_blocks == -1:
-            desc_end = "since the last difficulty change"
-        gauge = Gauge(
-            f"{METRIC_PREFIX}_hashps%s" % hashps_gauge_suffix(num_blocks),
-            "Estimated network hash rate per second %s" % desc_end,
-        )
-        UTXO_NODE_HASHPS_GAUGES[num_blocks] = gauge
-    return gauge
 
 
 def do_hashps_gauge(num_blocks: int) -> None:

--- a/utxo_prometheus_exporter.py
+++ b/utxo_prometheus_exporter.py
@@ -30,7 +30,6 @@ from typing import Dict
 from typing import List
 from typing import Union
 from typing import Callable
-from distutils.util import strtobool
 from wsgiref.simple_server import make_server
 
 import riprova
@@ -39,39 +38,9 @@ from bitcoin.rpc import JSONRPCError, InWarmupError, Proxy
 from prometheus_client import make_wsgi_app
 
 from prometheus_metrics import *
+from config import *
 
 logger = logging.getLogger("utxo-prometheus-exporter")
-
-# Set up logging to look similar to bitcoin logs (UTC).
-LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
-
-UTXO_NODE_RPC_SCHEME = os.environ.get("UTXO_NODE_RPC_SCHEME", "http")
-UTXO_NODE_RPC_HOST = os.environ.get("UTXO_NODE_RPC_HOST", "localhost")
-UTXO_NODE_RPC_PORT = os.environ.get("UTXO_NODE_RPC_PORT", "8332")
-UTXO_NODE_RPC_USER = os.environ.get("UTXO_NODE_RPC_USER")
-UTXO_NODE_RPC_PASSWORD = os.environ.get("UTXO_NODE_RPC_PASSWORD")
-UTXO_NODE_CONF_PATH = os.environ.get("UTXO_NODE_CONF_PATH")
-HASHPS_BLOCKS = [int(b) for b in os.environ.get("HASHPS_BLOCKS", "-1,1,120").split(",") if b != ""]
-SMART_FEES = [int(f) for f in os.environ.get("SMARTFEE_BLOCKS", "2,3,5,20").split(",") if f != ""]
-METRICS_ADDR = os.environ.get("METRICS_ADDR", "")  # empty = any address
-METRICS_PORT = int(os.environ.get("METRICS_PORT", "9332"))
-RETRIES = int(os.environ.get("RETRIES", 5))
-TIMEOUT = int(os.environ.get("TIMEOUT", 30))
-RATE_LIMIT_SECONDS = int(os.environ.get("RATE_LIMIT", 5))
-LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
-
-FETCH_UPTIME = strtobool(os.environ.get("FETCH_UPTIME", 'True'))
-FETCH_MEMINFO = strtobool(os.environ.get("FETCH_MEMINFO", 'True'))
-FETCH_BLOCKCHAININFO = strtobool(os.environ.get("FETCH_BLOCKCHAININFO", 'True'))
-FETCH_NETWORKINFO = strtobool(os.environ.get("FETCH_NETWORKINFO", 'True'))
-FETCH_CHAINTIPS = strtobool(os.environ.get("FETCH_CHAINTIPS", 'True'))
-FETCH_MEMPOOLINFO = strtobool(os.environ.get("FETCH_MEMPOOLINFO", 'True'))
-FETCH_NETTOTALS = strtobool(os.environ.get("FETCH_NETTOTALS", 'True'))
-FETCH_RPCINFO = strtobool(os.environ.get("FETCH_RPCINFO", 'True'))
-FETCH_TXSTATS = strtobool(os.environ.get("FETCH_TXSTATS", 'True'))
-FETCH_BANNED = strtobool(os.environ.get("FETCH_BANNED", 'True'))
-FETCH_SMART_FEES = strtobool(os.environ.get("FETCH_SMART_FEES", 'True'))
-FETCH_HASHP_BLOCKS = strtobool(os.environ.get("FETCH_HASHP_BLOCKS", 'True'))
 
 RETRY_EXCEPTIONS = (InWarmupError, ConnectionError, socket.timeout)
 

--- a/utxo_prometheus_exporter.py
+++ b/utxo_prometheus_exporter.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+
+# LICENSE information from upstream
 # bitcoind-monitor.py
 #
 # An exporter for Prometheus and Bitcoin Core.
@@ -38,101 +40,111 @@ from bitcoin.rpc import JSONRPCError, InWarmupError, Proxy
 from prometheus_client import make_wsgi_app, Gauge, Counter
 
 
-logger = logging.getLogger("bitcoin-exporter")
+logger = logging.getLogger("utxo-prometheus-exporter")
 
-# Create Prometheus metrics to track bitcoind stats.
-BITCOIN_BLOCKS = Gauge("bitcoin_blocks", "Block height")
-BITCOIN_DIFFICULTY = Gauge("bitcoin_difficulty", "Difficulty")
-BITCOIN_PEERS = Gauge("bitcoin_peers", "Number of peers")
-BITCOIN_CONN_IN = Gauge("bitcoin_conn_in", "Number of connections in")
-BITCOIN_CONN_OUT = Gauge("bitcoin_conn_out", "Number of connections out")
+# Set up logging to look similar to bitcoin logs (UTC).
+LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
 
-BITCOIN_HASHPS_GAUGES = {}  # type: Dict[int, Gauge]
-BITCOIN_ESTIMATED_SMART_FEE_GAUGES = {}  # type: Dict[int, Gauge]
+METRIC_PREFIX = "utxo_node"
 
-BITCOIN_WARNINGS = Counter("bitcoin_warnings", "Number of network or blockchain warnings detected")
-BITCOIN_UPTIME = Gauge("bitcoin_uptime", "Number of seconds the Bitcoin daemon has been running")
+UTXO_NODE_BLOCKS = Gauge(f"{METRIC_PREFIX}_blocks", "Block height")
+UTXO_NODE_DIFFICULTY = Gauge(f"{METRIC_PREFIX}_difficulty", "Difficulty")
+UTXO_NODE_PEERS = Gauge(f"{METRIC_PREFIX}_peers", "Number of peers")
+UTXO_NODE_CONN_IN = Gauge(f"{METRIC_PREFIX}_conn_in", "Number of connections in")
+UTXO_NODE_CONN_OUT = Gauge(f"{METRIC_PREFIX}_conn_out", "Number of connections out")
 
-BITCOIN_MEMINFO_USED = Gauge("bitcoin_meminfo_used", "Number of bytes used")
-BITCOIN_MEMINFO_FREE = Gauge("bitcoin_meminfo_free", "Number of bytes available")
-BITCOIN_MEMINFO_TOTAL = Gauge("bitcoin_meminfo_total", "Number of bytes managed")
-BITCOIN_MEMINFO_LOCKED = Gauge("bitcoin_meminfo_locked", "Number of bytes locked")
-BITCOIN_MEMINFO_CHUNKS_USED = Gauge("bitcoin_meminfo_chunks_used", "Number of allocated chunks")
-BITCOIN_MEMINFO_CHUNKS_FREE = Gauge("bitcoin_meminfo_chunks_free", "Number of unused chunks")
+UTXO_NODE_HASHPS_GAUGES = {}  # type: Dict[int, Gauge]
+UTXO_NODE_ESTIMATED_SMART_FEE_GAUGES = {}  # type: Dict[int, Gauge]
 
-BITCOIN_MEMPOOL_BYTES = Gauge("bitcoin_mempool_bytes", "Size of mempool in bytes")
-BITCOIN_MEMPOOL_SIZE = Gauge(
-    "bitcoin_mempool_size", "Number of unconfirmed transactions in mempool"
+UTXO_NODE_WARNINGS = Counter(
+    f"{METRIC_PREFIX}_warnings",
+    "Number of network or blockchain warnings detected"
 )
-BITCOIN_MEMPOOL_USAGE = Gauge("bitcoin_mempool_usage", "Total memory usage for the mempool")
-BITCOIN_MEMPOOL_UNBROADCAST = Gauge(
-    "bitcoin_mempool_unbroadcast", "Number of transactions waiting for acknowledgment"
+UTXO_NODE_UPTIME = Gauge(
+    f"{METRIC_PREFIX}_uptime",
+    "Number of seconds the node has been running"
 )
 
-BITCOIN_LATEST_BLOCK_HEIGHT = Gauge(
-    "bitcoin_latest_block_height", "Height or index of latest block"
+UTXO_NODE_MEMINFO_USED = Gauge(f"{METRIC_PREFIX}_meminfo_used", "Number of bytes used")
+UTXO_NODE_MEMINFO_FREE = Gauge(f"{METRIC_PREFIX}_meminfo_free", "Number of bytes available")
+UTXO_NODE_MEMINFO_TOTAL = Gauge(f"{METRIC_PREFIX}_meminfo_total", "Number of bytes managed")
+UTXO_NODE_MEMINFO_LOCKED = Gauge(f"{METRIC_PREFIX}_meminfo_locked", "Number of bytes locked")
+UTXO_NODE_MEMINFO_CHUNKS_USED = Gauge(f"{METRIC_PREFIX}_meminfo_chunks_used", "Number of allocated chunks")
+UTXO_NODE_MEMINFO_CHUNKS_FREE = Gauge(f"{METRIC_PREFIX}_meminfo_chunks_free", "Number of unused chunks")
+
+UTXO_NODE_MEMPOOL_BYTES = Gauge(f"{METRIC_PREFIX}_mempool_bytes", "Size of mempool in bytes")
+UTXO_NODE_MEMPOOL_SIZE = Gauge(
+    f"{METRIC_PREFIX}_mempool_size", "Number of unconfirmed transactions in mempool"
 )
-BITCOIN_LATEST_BLOCK_WEIGHT = Gauge(
-    "bitcoin_latest_block_weight", "Weight of latest block according to BIP 141"
-)
-BITCOIN_LATEST_BLOCK_SIZE = Gauge("bitcoin_latest_block_size", "Size of latest block in bytes")
-BITCOIN_LATEST_BLOCK_TXS = Gauge(
-    "bitcoin_latest_block_txs", "Number of transactions in latest block"
+UTXO_NODE_MEMPOOL_USAGE = Gauge(f"{METRIC_PREFIX}_mempool_usage", "Total memory usage for the mempool")
+UTXO_NODE_MEMPOOL_UNBROADCAST = Gauge(
+    f"{METRIC_PREFIX}_mempool_unbroadcast", "Number of transactions waiting for acknowledgment"
 )
 
-BITCOIN_TXCOUNT = Gauge("bitcoin_txcount", "Number of TX since the genesis block")
-
-BITCOIN_NUM_CHAINTIPS = Gauge("bitcoin_num_chaintips", "Number of known blockchain branches")
-
-BITCOIN_TOTAL_BYTES_RECV = Gauge("bitcoin_total_bytes_recv", "Total bytes received")
-BITCOIN_TOTAL_BYTES_SENT = Gauge("bitcoin_total_bytes_sent", "Total bytes sent")
-
-BITCOIN_LATEST_BLOCK_INPUTS = Gauge(
-    "bitcoin_latest_block_inputs", "Number of inputs in transactions of latest block"
+UTXO_NODE_LATEST_BLOCK_HEIGHT = Gauge(
+    f"{METRIC_PREFIX}_latest_block_height", "Height or index of latest block"
 )
-BITCOIN_LATEST_BLOCK_OUTPUTS = Gauge(
-    "bitcoin_latest_block_outputs", "Number of outputs in transactions of latest block"
+UTXO_NODE_LATEST_BLOCK_WEIGHT = Gauge(
+    f"{METRIC_PREFIX}_latest_block_weight", "Weight of latest block according to BIP 141"
 )
-BITCOIN_LATEST_BLOCK_VALUE = Gauge(
-    "bitcoin_latest_block_value", "Bitcoin value of all transactions in the latest block"
-)
-BITCOIN_LATEST_BLOCK_FEE = Gauge(
-    "bitcoin_latest_block_fee", "Total fee to process the latest block"
+UTXO_NODE_LATEST_BLOCK_SIZE = Gauge(f"{METRIC_PREFIX}_latest_block_size", "Size of latest block in bytes")
+UTXO_NODE_LATEST_BLOCK_TXS = Gauge(
+    f"{METRIC_PREFIX}_latest_block_txs", "Number of transactions in latest block"
 )
 
-BITCOIN_BAN_CREATED = Gauge(
-    "bitcoin_ban_created", "Time the ban was created", labelnames=["address", "reason"]
+UTXO_NODE_TXCOUNT = Gauge(f"{METRIC_PREFIX}_txcount", "Number of TX since the genesis block")
+
+UTXO_NODE_NUM_CHAINTIPS = Gauge(f"{METRIC_PREFIX}_num_chaintips", "Number of known blockchain branches")
+
+UTXO_NODE_TOTAL_BYTES_RECV = Gauge(f"{METRIC_PREFIX}_total_bytes_recv", "Total bytes received")
+UTXO_NODE_TOTAL_BYTES_SENT = Gauge(f"{METRIC_PREFIX}_total_bytes_sent", "Total bytes sent")
+
+UTXO_NODE_LATEST_BLOCK_INPUTS = Gauge(
+    f"{METRIC_PREFIX}_latest_block_inputs", "Number of inputs in transactions of latest block"
 )
-BITCOIN_BANNED_UNTIL = Gauge(
-    "bitcoin_banned_until", "Time the ban expires", labelnames=["address", "reason"]
+UTXO_NODE_LATEST_BLOCK_OUTPUTS = Gauge(
+    f"{METRIC_PREFIX}_latest_block_outputs", "Number of outputs in transactions of latest block"
+)
+UTXO_NODE_LATEST_BLOCK_VALUE = Gauge(
+    f"{METRIC_PREFIX}_latest_block_value", "Bitcoin value of all transactions in the latest block"
+)
+UTXO_NODE_LATEST_BLOCK_FEE = Gauge(
+    f"{METRIC_PREFIX}_latest_block_fee", "Total fee to process the latest block"
 )
 
-BITCOIN_SERVER_VERSION = Gauge("bitcoin_server_version", "The server version")
-BITCOIN_PROTOCOL_VERSION = Gauge("bitcoin_protocol_version", "The protocol version of the server")
-
-BITCOIN_SIZE_ON_DISK = Gauge("bitcoin_size_on_disk", "Estimated size of the block and undo files")
-
-BITCOIN_VERIFICATION_PROGRESS = Gauge(
-    "bitcoin_verification_progress", "Estimate of verification progress [0..1]"
+UTXO_NODE_BAN_CREATED = Gauge(
+    f"{METRIC_PREFIX}_ban_created", "Time the ban was created", labelnames=["address", "reason"]
+)
+UTXO_NODE_BANNED_UNTIL = Gauge(
+    f"{METRIC_PREFIX}_banned_until", "Time the ban expires", labelnames=["address", "reason"]
 )
 
-BITCOIN_RPC_ACTIVE = Gauge("bitcoin_rpc_active", "Number of RPC calls being processed")
+UTXO_NODE_SERVER_VERSION = Gauge(f"{METRIC_PREFIX}_server_version", "The server version")
+UTXO_NODE_PROTOCOL_VERSION = Gauge(f"{METRIC_PREFIX}_protocol_version", "The protocol version of the server")
+
+UTXO_NODE_SIZE_ON_DISK = Gauge(f"{METRIC_PREFIX}_size_on_disk", "Estimated size of the block and undo files")
+
+UTXO_NODE_VERIFICATION_PROGRESS = Gauge(
+    f"{METRIC_PREFIX}_verification_progress", "Estimate of verification progress [0..1]"
+)
+
+UTXO_NODE_RPC_ACTIVE = Gauge(f"{METRIC_PREFIX}_rpc_active", "Number of RPC calls being processed")
 
 EXPORTER_ERRORS = Counter(
-    "bitcoin_exporter_errors", "Number of errors encountered by the exporter", labelnames=["type"]
+    f"{METRIC_PREFIX}_exporter_errors", "Number of errors encountered by the exporter", labelnames=["type"]
 )
 PROCESS_TIME = Counter(
-    "bitcoin_exporter_process_time", "Time spent processing metrics from bitcoin node"
+    f"{METRIC_PREFIX}_exporter_process_time", "Time spent processing metrics from node"
 )
 
 SATS_PER_COIN = Decimal(1e8)
 
-BITCOIN_RPC_SCHEME = os.environ.get("BITCOIN_RPC_SCHEME", "http")
-BITCOIN_RPC_HOST = os.environ.get("BITCOIN_RPC_HOST", "localhost")
-BITCOIN_RPC_PORT = os.environ.get("BITCOIN_RPC_PORT", "8332")
-BITCOIN_RPC_USER = os.environ.get("BITCOIN_RPC_USER")
-BITCOIN_RPC_PASSWORD = os.environ.get("BITCOIN_RPC_PASSWORD")
-BITCOIN_CONF_PATH = os.environ.get("BITCOIN_CONF_PATH")
+UTXO_NODE_RPC_SCHEME = os.environ.get("UTXO_NODE_RPC_SCHEME", "http")
+UTXO_NODE_RPC_HOST = os.environ.get("UTXO_NODE_RPC_HOST", "localhost")
+UTXO_NODE_RPC_PORT = os.environ.get("UTXO_NODE_RPC_PORT", "8332")
+UTXO_NODE_RPC_USER = os.environ.get("UTXO_NODE_RPC_USER")
+UTXO_NODE_RPC_PASSWORD = os.environ.get("UTXO_NODE_RPC_PASSWORD")
+UTXO_NODE_CONF_PATH = os.environ.get("UTXO_NODE_CONF_PATH")
 HASHPS_BLOCKS = [int(b) for b in os.environ.get("HASHPS_BLOCKS", "-1,1,120").split(",") if b != ""]
 SMART_FEES = [int(f) for f in os.environ.get("SMARTFEE_BLOCKS", "2,3,5,20").split(",") if f != ""]
 METRICS_ADDR = os.environ.get("METRICS_ADDR", "")  # empty = any address
@@ -175,23 +187,23 @@ def error_evaluator(e: Exception) -> bool:
 def rpc_client_factory():
     # Configuration is done in this order of precedence:
     #   - Explicit config file.
-    #   - BITCOIN_RPC_USER and BITCOIN_RPC_PASSWORD environment variables.
+    #   - UTXO_NODE_RPC_USER and UTXO_NODE_RPC_PASSWORD environment variables.
     #   - Default bitcoin config file (as handled by Proxy.__init__).
     use_conf = (
-        (BITCOIN_CONF_PATH is not None)
-        or (BITCOIN_RPC_USER is None)
-        or (BITCOIN_RPC_PASSWORD is None)
+        (UTXO_NODE_CONF_PATH is not None)
+        or (UTXO_NODE_RPC_USER is None)
+        or (UTXO_NODE_RPC_PASSWORD is None)
     )
 
     if use_conf:
-        logger.info("Using config file: %s", BITCOIN_CONF_PATH or "<default>")
-        return lambda: Proxy(btc_conf_file=BITCOIN_CONF_PATH, timeout=TIMEOUT)
+        logger.info("Using config file: %s", UTXO_NODE_CONF_PATH or "<default>")
+        return lambda: Proxy(btc_conf_file=UTXO_NODE_CONF_PATH, timeout=TIMEOUT)
     else:
-        host = BITCOIN_RPC_HOST
-        host = "{}:{}@{}".format(BITCOIN_RPC_USER, BITCOIN_RPC_PASSWORD, host)
-        if BITCOIN_RPC_PORT:
-            host = "{}:{}".format(host, BITCOIN_RPC_PORT)
-        service_url = "{}://{}".format(BITCOIN_RPC_SCHEME, host)
+        host = UTXO_NODE_RPC_HOST
+        host = "{}:{}@{}".format(UTXO_NODE_RPC_USER, UTXO_NODE_RPC_PASSWORD, host)
+        if UTXO_NODE_RPC_PORT:
+            host = "{}:{}".format(host, UTXO_NODE_RPC_PORT)
+        service_url = "{}://{}".format(UTXO_NODE_RPC_SCHEME, host)
         logger.info("Using environment configuration")
         return lambda: Proxy(service_url=service_url, timeout=TIMEOUT)
 
@@ -206,7 +218,7 @@ def rpc_client():
     on_retry=on_retry,
     error_evaluator=error_evaluator,
 )
-def bitcoinrpc(*args) -> RpcResult:
+def exec_rpc_call(*args) -> RpcResult:
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug("RPC call: " + " ".join(str(a) for a in args))
 
@@ -219,30 +231,30 @@ def bitcoinrpc(*args) -> RpcResult:
 @lru_cache(maxsize=1)
 def getblockstats(block_hash: str):
     try:
-        block = bitcoinrpc(
+        block = exec_rpc_call(
             "getblockstats",
             block_hash,
             ["total_size", "total_weight", "totalfee", "txs", "height", "ins", "outs", "total_out"],
         )
     except Exception:
-        logger.exception("Failed to retrieve block " + block_hash + " statistics from bitcoind.")
+        logger.exception("Failed to retrieve block " + block_hash + " statistics from node.")
         return None
     return block
 
 
 def smartfee_gauge(num_blocks: int) -> Gauge:
-    gauge = BITCOIN_ESTIMATED_SMART_FEE_GAUGES.get(num_blocks)
+    gauge = UTXO_NODE_ESTIMATED_SMART_FEE_GAUGES.get(num_blocks)
     if gauge is None:
         gauge = Gauge(
-            "bitcoin_est_smart_fee_%d" % num_blocks,
+            f"{METRIC_PREFIX}_est_smart_fee_%d" % num_blocks,
             "Estimated smart fee per kilobyte for confirmation in %d blocks" % num_blocks,
         )
-        BITCOIN_ESTIMATED_SMART_FEE_GAUGES[num_blocks] = gauge
+        UTXO_NODE_ESTIMATED_SMART_FEE_GAUGES[num_blocks] = gauge
     return gauge
 
 
 def do_smartfee(num_blocks: int) -> None:
-    smartfee = bitcoinrpc("estimatesmartfee", num_blocks).get("feerate")
+    smartfee = exec_rpc_call("estimatesmartfee", num_blocks).get("feerate")
     if smartfee is not None:
         gauge = smartfee_gauge(num_blocks)
         gauge.set(smartfee)
@@ -257,21 +269,21 @@ def hashps_gauge_suffix(nblocks):
 
 
 def hashps_gauge(num_blocks: int) -> Gauge:
-    gauge = BITCOIN_HASHPS_GAUGES.get(num_blocks)
+    gauge = UTXO_NODE_HASHPS_GAUGES.get(num_blocks)
     if gauge is None:
         desc_end = "for the last %d blocks" % num_blocks
         if num_blocks == -1:
             desc_end = "since the last difficulty change"
         gauge = Gauge(
-            "bitcoin_hashps%s" % hashps_gauge_suffix(num_blocks),
+            f"{METRIC_PREFIX}_hashps%s" % hashps_gauge_suffix(num_blocks),
             "Estimated network hash rate per second %s" % desc_end,
         )
-        BITCOIN_HASHPS_GAUGES[num_blocks] = gauge
+        UTXO_NODE_HASHPS_GAUGES[num_blocks] = gauge
     return gauge
 
 
 def do_hashps_gauge(num_blocks: int) -> None:
-    hps = float(bitcoinrpc("getnetworkhashps", num_blocks))
+    hps = float(exec_rpc_call("getnetworkhashps", num_blocks))
     if hps is not None:
         gauge = hashps_gauge(num_blocks)
         gauge.set(hps)
@@ -288,93 +300,93 @@ def exception_count(e: Exception) -> None:
 
 
 def fetch_uptime() -> None:
-    uptime = bitcoinrpc("uptime")
+    uptime = exec_rpc_call("uptime")
     if uptime is not None:
-        BITCOIN_UPTIME.set(uptime)
+        UTXO_NODE_UPTIME.set(uptime)
 
 def fetch_meminfo() -> None:
-    meminfo = bitcoinrpc("getmemoryinfo", "stats")["locked"]
+    meminfo = exec_rpc_call("getmemoryinfo", "stats")["locked"]
     if meminfo is not None:
-        BITCOIN_MEMINFO_USED.set(meminfo["used"])
-        BITCOIN_MEMINFO_FREE.set(meminfo["free"])
-        BITCOIN_MEMINFO_TOTAL.set(meminfo["total"])
-        BITCOIN_MEMINFO_LOCKED.set(meminfo["locked"])
-        BITCOIN_MEMINFO_CHUNKS_USED.set(meminfo["chunks_used"])
-        BITCOIN_MEMINFO_CHUNKS_FREE.set(meminfo["chunks_free"])
+        UTXO_NODE_MEMINFO_USED.set(meminfo["used"])
+        UTXO_NODE_MEMINFO_FREE.set(meminfo["free"])
+        UTXO_NODE_MEMINFO_TOTAL.set(meminfo["total"])
+        UTXO_NODE_MEMINFO_LOCKED.set(meminfo["locked"])
+        UTXO_NODE_MEMINFO_CHUNKS_USED.set(meminfo["chunks_used"])
+        UTXO_NODE_MEMINFO_CHUNKS_FREE.set(meminfo["chunks_free"])
 
 def fetch_blockchaininfo() -> None:
-    blockchaininfo = bitcoinrpc("getblockchaininfo")
+    blockchaininfo = exec_rpc_call("getblockchaininfo")
     if blockchaininfo is not None:
-        BITCOIN_BLOCKS.set(blockchaininfo["blocks"])
-        BITCOIN_DIFFICULTY.set(blockchaininfo["difficulty"])
-        BITCOIN_SIZE_ON_DISK.set(blockchaininfo["size_on_disk"])
-        BITCOIN_VERIFICATION_PROGRESS.set(blockchaininfo["verificationprogress"])
+        UTXO_NODE_BLOCKS.set(blockchaininfo["blocks"])
+        UTXO_NODE_DIFFICULTY.set(blockchaininfo["difficulty"])
+        UTXO_NODE_SIZE_ON_DISK.set(blockchaininfo["size_on_disk"])
+        UTXO_NODE_VERIFICATION_PROGRESS.set(blockchaininfo["verificationprogress"])
 
         latest_blockstats = getblockstats(str(blockchaininfo["bestblockhash"]))
         if latest_blockstats is not None:
-            BITCOIN_LATEST_BLOCK_SIZE.set(latest_blockstats["total_size"])
-            BITCOIN_LATEST_BLOCK_TXS.set(latest_blockstats["txs"])
-            BITCOIN_LATEST_BLOCK_HEIGHT.set(latest_blockstats["height"])
-            BITCOIN_LATEST_BLOCK_WEIGHT.set(latest_blockstats["total_weight"])
-            BITCOIN_LATEST_BLOCK_INPUTS.set(latest_blockstats["ins"])
-            BITCOIN_LATEST_BLOCK_OUTPUTS.set(latest_blockstats["outs"])
-            BITCOIN_LATEST_BLOCK_VALUE.set(latest_blockstats["total_out"] / SATS_PER_COIN)
-            BITCOIN_LATEST_BLOCK_FEE.set(latest_blockstats["totalfee"] / SATS_PER_COIN)
+            UTXO_NODE_LATEST_BLOCK_SIZE.set(latest_blockstats["total_size"])
+            UTXO_NODE_LATEST_BLOCK_TXS.set(latest_blockstats["txs"])
+            UTXO_NODE_LATEST_BLOCK_HEIGHT.set(latest_blockstats["height"])
+            UTXO_NODE_LATEST_BLOCK_WEIGHT.set(latest_blockstats["total_weight"])
+            UTXO_NODE_LATEST_BLOCK_INPUTS.set(latest_blockstats["ins"])
+            UTXO_NODE_LATEST_BLOCK_OUTPUTS.set(latest_blockstats["outs"])
+            UTXO_NODE_LATEST_BLOCK_VALUE.set(latest_blockstats["total_out"] / SATS_PER_COIN)
+            UTXO_NODE_LATEST_BLOCK_FEE.set(latest_blockstats["totalfee"] / SATS_PER_COIN)
 
 def fetch_networkinfo() -> None:
-    networkinfo = bitcoinrpc("getnetworkinfo")
+    networkinfo = exec_rpc_call("getnetworkinfo")
     if networkinfo is not None:
-        BITCOIN_PEERS.set(networkinfo["connections"])
+        UTXO_NODE_PEERS.set(networkinfo["connections"])
         if "connections_in" in networkinfo:
-            BITCOIN_CONN_IN.set(networkinfo["connections_in"])
+            UTXO_NODE_CONN_IN.set(networkinfo["connections_in"])
         if "connections_out" in networkinfo:
-            BITCOIN_CONN_OUT.set(networkinfo["connections_out"])
+            UTXO_NODE_CONN_OUT.set(networkinfo["connections_out"])
 
-        BITCOIN_SERVER_VERSION.set(networkinfo["version"])
-        BITCOIN_PROTOCOL_VERSION.set(networkinfo["protocolversion"])
+        UTXO_NODE_SERVER_VERSION.set(networkinfo["version"])
+        UTXO_NODE_PROTOCOL_VERSION.set(networkinfo["protocolversion"])
 
         if networkinfo["warnings"]:
-            BITCOIN_WARNINGS.inc()
+            UTXO_NODE_WARNINGS.inc()
 
 def fetch_chaintips() -> None:
-    chaintips = bitcoinrpc("getchaintips")
+    chaintips = exec_rpc_call("getchaintips")
     if chaintips is not None:
-        BITCOIN_NUM_CHAINTIPS.set(len(chaintips))
+        UTXO_NODE_NUM_CHAINTIPS.set(len(chaintips))
 
 def fetch_mempoolinfo() -> None:
-    mempool = bitcoinrpc("getmempoolinfo")
+    mempool = exec_rpc_call("getmempoolinfo")
     if mempool is not None:
-        BITCOIN_MEMPOOL_BYTES.set(mempool["bytes"])
-        BITCOIN_MEMPOOL_SIZE.set(mempool["size"])
-        BITCOIN_MEMPOOL_USAGE.set(mempool["usage"])
+        UTXO_NODE_MEMPOOL_BYTES.set(mempool["bytes"])
+        UTXO_NODE_MEMPOOL_SIZE.set(mempool["size"])
+        UTXO_NODE_MEMPOOL_USAGE.set(mempool["usage"])
         if "unbroadcastcount" in mempool:
-            BITCOIN_MEMPOOL_UNBROADCAST.set(mempool["unbroadcastcount"])
+            UTXO_NODE_MEMPOOL_UNBROADCAST.set(mempool["unbroadcastcount"])
 
 def fetch_nettotals() -> None:
-    nettotals = bitcoinrpc("getnettotals")
+    nettotals = exec_rpc_call("getnettotals")
     if nettotals is not None:
-        BITCOIN_TOTAL_BYTES_RECV.set(nettotals["totalbytesrecv"])
-        BITCOIN_TOTAL_BYTES_SENT.set(nettotals["totalbytessent"])
+        UTXO_NODE_TOTAL_BYTES_RECV.set(nettotals["totalbytesrecv"])
+        UTXO_NODE_TOTAL_BYTES_SENT.set(nettotals["totalbytessent"])
 
 def fetch_rpcinfo() -> None:
-    rpcinfo = bitcoinrpc("getrpcinfo")
+    rpcinfo = exec_rpc_call("getrpcinfo")
     if rpcinfo is not None:
         # Subtract one because we don't want to count the "getrpcinfo" call itself
-        BITCOIN_RPC_ACTIVE.set(len(rpcinfo["active_commands"]) - 1)
+        UTXO_NODE_RPC_ACTIVE.set(len(rpcinfo["active_commands"]) - 1)
 
 def fetch_txstats() -> None:
-    txstats = bitcoinrpc("getchaintxstats")
+    txstats = exec_rpc_call("getchaintxstats")
     if txstats is not None:
-        BITCOIN_TXCOUNT.set(txstats["txcount"])
+        UTXO_NODE_TXCOUNT.set(txstats["txcount"])
 
 def fetch_banned() -> None:
-    banned = bitcoinrpc("listbanned")
+    banned = exec_rpc_call("listbanned")
     if banned is not None:
         for ban in banned:
-            BITCOIN_BAN_CREATED.labels(
+            UTXO_NODE_BAN_CREATED.labels(
                 address=ban["address"], reason=ban.get("ban_reason", "manually added")
             ).set(ban["ban_created"])
-            BITCOIN_BANNED_UNTIL.labels(
+            UTXO_NODE_BANNED_UNTIL.labels(
                 address=ban["address"], reason=ban.get("ban_reason", "manually added")
             ).set(ban["banned_until"])
 
@@ -425,17 +437,14 @@ def fetch(fetch_function):
         logger.error("Fetch failed during retry. Cause: " + str(e))
         exception_count(e)
     except JSONRPCError as e:
-        logger.debug("Bitcoin RPC error refresh", exc_info=True)
+        logger.debug("RPC error refresh", exc_info=True)
         exception_count(e)
     except json.decoder.JSONDecodeError as e:
         logger.error("RPC call did not return JSON. Bad credentials? " + str(e))
         sys.exit(1)
 
 def main():
-    # Set up logging to look similar to bitcoin logs (UTC).
-    logging.basicConfig(
-        format="%(asctime)s %(levelname)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%SZ"
-    )
+    logging.basicConfig(format=LOG_FORMAT, datefmt="%Y-%m-%dT%H:%M:%SZ")
     logging.Formatter.converter = time.gmtime
     logger.setLevel(LOG_LEVEL)
 


### PR DESCRIPTION
* Prometheus metric names have `utxo_node` prefix instead of the old `bitcoin`
* Env variables have `UTXO_NODE` prefix instead of the old `BITCOIN`
*  All prometheus metrics have label `blockchain` which can be set with `UTXO_NODE_BLOCKCHAIN_NAME` env variable.
*  Configuration has been extracted to separate file - `config.py`
*  Prometheus metrics have been extracted to separate file - `prometheus_metrics.py`
* Readme and changelog updated
* Grafana dashboard updated
* Version 1.0.0 released